### PR TITLE
Add CI workflow to build and test on push and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race -v ./...


### PR DESCRIPTION
## Summary
- Adds a simple GitHub Actions workflow that builds and runs tests on every push and pull request.

## Details
- Sets up Go using the version from `go.mod` (stays in sync automatically).
- Runs `go build ./...` then `go test -race -v ./...` (race detector enabled, relevant for the sharded LRU).

## Testing
- Build and tests with `-race` pass locally.